### PR TITLE
[WIP] Reload on all redirects to handle Cloudflare Access auth expiration

### DIFF
--- a/packages/loot-core/src/platform/server/fetch/index.ts
+++ b/packages/loot-core/src/platform/server/fetch/index.ts
@@ -2,17 +2,19 @@ import * as connection from '../connection';
 
 export const fetch = async (
   input: RequestInfo | URL,
-  options?: RequestInit,
+  options: RequestInit = {},
 ): Promise<Response> => {
+
+  // Set redirect to manual so that we can detect and respond to redirects. 
+  if (!options.redirect) options.redirect = 'manual';
+
   const response = await globalThis.fetch(input, options);
 
-  // Detect if the API query has been redirected to a different origin. This may indicate that the
-  // request has been intercepted by an authentication proxy
-  const originalUrl = new URL(input instanceof Request ? input.url : input);
-  const responseUrl = new URL(response.url);
-  if (response.redirected && responseUrl.host !== originalUrl.host) {
+  // Authentication proxies redirect when authentication has expired. In this case, 
+  // we want to fully reload and yeild control from the service worker back to the server.
+  if (response.type === 'opaqueredirect') {
     connection.send('api-fetch-redirected');
-    throw new Error(`API request redirected to ${responseUrl.host}`);
+    throw new Error(`API request redirected to unknown destination`);
   }
 
   return response;

--- a/packages/loot-core/src/platform/server/fetch/index.ts
+++ b/packages/loot-core/src/platform/server/fetch/index.ts
@@ -14,7 +14,7 @@ export const fetch = async (
   // we want to fully reload and yeild control from the service worker back to the server.
   if (response.type === 'opaqueredirect') {
     connection.send('api-fetch-redirected');
-    throw new Error(`API request redirected to unknown destination`);
+    throw new Error(`API request redirected`);
   }
 
   return response;

--- a/upcoming-release-notes/4706.md
+++ b/upcoming-release-notes/4706.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [rgoldfinger]
+---
+
+Reload on all redirects to handle Cloudflare Access expiration 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://github.com/actualbudget/docs#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->

Fixes #4422


This PR addresses an issue when running Actual behind Cloudflare Access. When the Access token expires, the client is unable to reach the server. This is especially problematic on mobile Safari which seems to have no way to force a hard reload. 

When this happens, requests to the Actual server are 302 redirected to the Cloudflare login page, but the redirected url hits a CORS error. 

```
Access to fetch at 'https://<cf-account-name>.cloudflareaccess.com/cdn-cgi/access/login/<fqdn>?kid=<redacted>&redirect_url=%2Fsync%2Fsync&meta=<redacted>' (redirected from 'https://<fqdn>/sync/sync') from origin 'https://<fqdn>' 
has been blocked by CORS policy: No 'Access-Control-Allow-Origin' header is present on the requested resource. 
If an opaque response serves your needs, set the request's mode to 'no-cors' to fetch the resource with CORS disabled.
```

The solution implemented here was inspired by a [similar fix to the same issue in Silver Bullet](https://github.com/silverbulletmd/silverbullet/issues/1091). 

 By setting `redirect: 'manual` when making the fetch request, we can detect this redirect.

[From MDN](https://developer.mozilla.org/en-US/docs/Web/API/Response/type):
> `opaqueredirect`: The fetch request was made with redirect: "manual". The Response's status is 0, headers are empty, body is null and trailer is empty.
 
### Is this change safe to make?

In https://github.com/actualbudget/actual/pull/3286, we started reloading whenever the origin changed. Therefore, this change should only catch the additional case of redirects where the origin stayed the same, but the path changed. 

I have searched the codebase for any cases when this might be happening, and could not find any. I searched for `.redirect` (`res.redirect`), `redirect`, `301`, `302`, and `.location` (`res.location`). 

